### PR TITLE
Update Slack Link in index.php

### DIFF
--- a/index.php
+++ b/index.php
@@ -185,7 +185,7 @@ $isThisATA = $auth ? verifyTA(phpCAS::getUser()) : false;
 
 
 		<h4>
-			<center>Please join the <a target="_blank" rel="noopener noreferrer" href="https://join.slack.com/t/cs240-fall2024/shared_invite/zt-2pxui8a4w-Iyvq5X8xoiTKo8P2YPN~qg"> course Slack</a>. See our TA schedule <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/document/d/12ZrcsQAfVirCuCwzI0TKX_tSPyBOjqB9vDE-sx1n_S0/edit">here</a></center>
+			<center>Please join the <a target="_blank" rel="noopener noreferrer" href="https://cs240.click/slack"> course Slack</a>. See our TA schedule <a target="_blank" rel="noopener noreferrer" href="https://docs.google.com/document/d/12ZrcsQAfVirCuCwzI0TKX_tSPyBOjqB9vDE-sx1n_S0/edit">here</a></center>
 		</h4>
 
 


### PR DESCRIPTION
A student joined using the outdated Slack link from this repository. Now, because of the new feature provided by https://github.com/softwareconstruction240/autograder/pull/608, we can always have the link pointing to a redirect to a relevant Slack Link.